### PR TITLE
ALFREDOPS-815 Disable search check logging

### DIFF
--- a/alfresco-solr-query-analytics/src/main/amp/config/alfresco/module/alfresco-solr-query-analytics/log4j.properties
+++ b/alfresco-solr-query-analytics/src/main/amp/config/alfresco/module/alfresco-solr-query-analytics/log4j.properties
@@ -1,6 +1,6 @@
 # SOLR query Logger
 # Define the file appender
-log4j.appender.solrQueryLog=util.CustomLog4jAppender
+log4j.appender.solrQueryLog=eu.xenit.util.CustomLog4jAppender
 log4j.appender.solrQueryLog.File=/usr/local/tomcat/logs/solrquery.log
 log4j.appender.solrQueryLog.Append=true
 log4j.appender.solrQueryLog.encoding=UTF-8

--- a/alfresco-solr-query-analytics/src/main/amp/config/alfresco/module/alfresco-solr-query-analytics/module-context.xml
+++ b/alfresco-solr-query-analytics/src/main/amp/config/alfresco/module/alfresco-solr-query-analytics/module-context.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE beans PUBLIC '-//SPRING//DTD BEAN//EN' 'http://www.springframework.org/dtd/spring-beans.dtd'>
 <beans>
-    <bean id="SolrQueryParser" class="util.SolrQueryParser">
+    <bean id="SolrQueryParser" class="eu.xenit.util.SolrQueryParser">
         <property name="namespaceService">
             <ref bean="namespaceService" />
         </property>

--- a/alfresco-solr-query-analytics/src/main/java/eu/xenit/subsystems/patches/solr/SolrDebugQueryHTTPClient.java
+++ b/alfresco-solr-query-analytics/src/main/java/eu/xenit/subsystems/patches/solr/SolrDebugQueryHTTPClient.java
@@ -112,8 +112,8 @@ import org.json.JSONTokener;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.extensions.surf.util.I18NUtil;
-import util.SolrQueryParser;
-import util.SolrTimingParser;
+import eu.xenit.util.SolrQueryParser;
+import eu.xenit.util.SolrTimingParser;
 
 /**
  * @author Andy

--- a/alfresco-solr-query-analytics/src/main/java/eu/xenit/subsystems/patches/solr/SolrDebugQueryHTTPClient.java
+++ b/alfresco-solr-query-analytics/src/main/java/eu/xenit/subsystems/patches/solr/SolrDebugQueryHTTPClient.java
@@ -1165,7 +1165,7 @@ public class SolrDebugQueryHTTPClient extends AbstractSolrQueryHTTPClient implem
 
             JSONResult results = jsonProcessor.getResult(json);
 
-            if (s_logger.isDebugEnabled())
+            if (s_logger.isDebugEnabled() && !body.optString("query","missing-query").strip().equals("abeecher"))
             {
                 if(!isUseSolrDebug()) {
                     s_logger.debug("Legacy solr logging:");

--- a/alfresco-solr-query-analytics/src/main/java/eu/xenit/util/CustomLog4jAppender.java
+++ b/alfresco-solr-query-analytics/src/main/java/eu/xenit/util/CustomLog4jAppender.java
@@ -1,4 +1,4 @@
-package util;
+package eu.xenit.util;
 
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Layout;

--- a/alfresco-solr-query-analytics/src/main/java/eu/xenit/util/SolrQueryParser.java
+++ b/alfresco-solr-query-analytics/src/main/java/eu/xenit/util/SolrQueryParser.java
@@ -1,4 +1,4 @@
-package util;
+package eu.xenit.util;
 
 import org.json.JSONObject;
 import org.slf4j.Logger;

--- a/alfresco-solr-query-analytics/src/main/java/eu/xenit/util/SolrTimingParser.java
+++ b/alfresco-solr-query-analytics/src/main/java/eu/xenit/util/SolrTimingParser.java
@@ -1,4 +1,4 @@
-package util;
+package eu.xenit.util;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/alfresco-solr-query-analytics/src/test/java/util/SolrQueryParserTest.java
+++ b/alfresco-solr-query-analytics/src/test/java/util/SolrQueryParserTest.java
@@ -1,5 +1,6 @@
 package util;
 
+import eu.xenit.util.SolrQueryParser;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/alfresco-solr-query-analytics/src/test/java/util/SolrTimingParserTest.java
+++ b/alfresco-solr-query-analytics/src/test/java/util/SolrTimingParserTest.java
@@ -1,5 +1,6 @@
 package util;
 
+import eu.xenit.util.SolrTimingParser;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
The search query: TEXT:"abeecher" is used as a regular scheduled check for alerting. Since this pollutes the data with non-human searches don't log the query at all.